### PR TITLE
Fix typo get_app_runnig_status.

### DIFF
--- a/SDKLibrary/com/cloudMedia/theKuroBox/sdk/app/application.py
+++ b/SDKLibrary/com/cloudMedia/theKuroBox/sdk/app/application.py
@@ -35,8 +35,12 @@ class Application(object):
     '''
     
     __unset__ = []
-    
-    def get_app_runnig_status(self):
+
+    def get_app_runnig_status(self, *args, **kwargs):
+	'''Backwards compatibility for typo, go to get_app_running_status.'''
+	return get_app_running_status(*args, **kwargs)
+
+    def get_app_running_status(self):
         '''
         Get whether this app is running or paused
         Return True / False


### PR DESCRIPTION
Fix the typo "get_app_runnig_status" in a backwards compatible manner.